### PR TITLE
bugfix link to slakh.com in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Utilities for common tasks with the Slakh dataset.
 ## About Slakh
 The Synthesized Lakh (Slakh) Dataset is a new dataset for audio source separation that is synthesized from the [Lakh MIDI Dataset v0.1](https://colinraffel.com/projects/lmd/) using professional-grade sample-based virtual instruments.  **Slakh2100** contains 2100 automatically mixed tracks and accompanying MIDI files synthesized using a professional-grade sampling engine. The tracks in **Slakh2100** are split into training (1500 tracks), validation (375 tracks), and test (225 tracks) subsets, totaling **145 hours** of mixtures.
 
-Slakh is brought to you by [Mitsubishi Electric Research Lab (MERL)](http://www.merl.com/) and the [Interactive Audio Lab at Northwestern University](http://music.cs.northwestern.edu/). For more info, please visit [the Slakh website](www.slakh.com/).
+Slakh is brought to you by [Mitsubishi Electric Research Lab (MERL)](http://www.merl.com/) and the [Interactive Audio Lab at Northwestern University](http://music.cs.northwestern.edu/). For more info, please visit [the Slakh website](https://www.slakh.com/).
 
 
 ## Table of Contents


### PR DESCRIPTION
Before: `www.slakh.com`, redirecting to `https://github.com/ethman/slakh-utils/blob/master/www.slakh.com`
After: `https://www.slakh.com`