### PR TITLE
Simple naming fix and pycharm-friendly gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# PyCharm project settings
+.idea
+
 # Rope project settings
 .ropeproject
 

--- a/splits/resplit_slakh.py
+++ b/splits/resplit_slakh.py
@@ -33,7 +33,7 @@ def do_all_updates(slakh_base_dir, new_splits_file):
 
 
 def reset(slakh_base_dir):
-    split_dirs = ['train', 'val', 'test', 'omitted']
+    split_dirs = ['train', 'validation', 'test', 'omitted']
 
     track_dirs = []
     for split in split_dirs:
@@ -50,7 +50,7 @@ def reset(slakh_base_dir):
         if track_id <= 'Track01500':
             dest_path = os.path.join(slakh_base_dir, 'train', track_id)
         elif track_id <= 'Track01875':
-            dest_path = os.path.join(slakh_base_dir, 'val', track_id)
+            dest_path = os.path.join(slakh_base_dir, 'validation', track_id)
         else:
             dest_path = os.path.join(slakh_base_dir, 'test', track_id)
 


### PR DESCRIPTION
Without this fix, the reset does not work properly, and results in half of the files in "validation/" and the other half in "val/"